### PR TITLE
Refactor query context

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod query_context;
 mod configuration;
 mod log_file;
+mod query_request;
 
 
 #[macro_use]

--- a/src/query_context.rs
+++ b/src/query_context.rs
@@ -5,76 +5,76 @@ use log_file;
 use log_ql;
 
 pub struct QueryContext {
-  working_directory: PathBuf,
-  configuration: Configuration
+    working_directory: PathBuf,
+    configuration: Configuration
 }
 
 impl QueryContext {
-  pub fn new(working_directory: &str, configuration: Configuration) -> Result<QueryContext, String> {
-    let src_dir = PathBuf::from(working_directory);
-    let working_dir = match fs::canonicalize(&src_dir) {
-      Ok(p) => p,
-      Err(_) => return Err(format!("Failed to get absolute path from {:?}", working_directory))
-    };
+    pub fn new(working_directory: &str, configuration: Configuration) -> Result<QueryContext, String> {
+        let src_dir = PathBuf::from(working_directory);
+        let working_dir = match fs::canonicalize(&src_dir) {
+            Ok(p) => p,
+            Err(_) => return Err(format!("Failed to get absolute path from {:?}", working_directory))
+        };
 
-    Ok(QueryContext {
-      working_directory: working_dir,
-      configuration: configuration
-    })
-  }
-
-  fn parse(&self, query: String) -> Result<(String, Vec<String>, String, String), String> {
-    let mut parser = log_ql::parser::Parser::new(query);
-    let query_ast = parser.parse()?;
-    let log_filename;
-    let query_fields;
-    let conditional_field;
-    let conditional_value;
-
-    let left_node = match query_ast.left {
-      Some(n) => n,
-      None => return Err("Expected Log file node, got None".into())
-    };
-
-    let right_node = match query_ast.right {
-      Some(n) => n,
-      None => return Err("Expected conditional query node, got None".into())
-    };
-
-    if let log_ql::parser::GrammarItem::LogFile { ref fields, ref filename } = left_node.entry {
-      log_filename = filename.clone();
-      query_fields = fields.clone();
-    } else {
-      return Err("Couldn't deref Logfile node".into());
+        Ok(QueryContext {
+            working_directory: working_dir,
+            configuration: configuration
+        })
     }
 
-    if let log_ql::parser::GrammarItem::Condition { ref field, ref value } = right_node.entry {
-      conditional_field = field.clone();
-      conditional_value = value.clone();
-    } else {
-      return Err("Couldn't deref Conditional node".into());
+    fn parse(&self, query: String) -> Result<(String, Vec<String>, String, String), String> {
+        let mut parser = log_ql::parser::Parser::new(query);
+        let query_ast = parser.parse()?;
+        let log_filename;
+        let query_fields;
+        let conditional_field;
+        let conditional_value;
+
+        let left_node = match query_ast.left {
+            Some(n) => n,
+            None => return Err("Expected Log file node, got None".into())
+        };
+
+        let right_node = match query_ast.right {
+            Some(n) => n,
+            None => return Err("Expected conditional query node, got None".into())
+        };
+
+        if let log_ql::parser::GrammarItem::LogFile { ref fields, ref filename } = left_node.entry {
+            log_filename = filename.clone();
+            query_fields = fields.clone();
+        } else {
+            return Err("Couldn't deref Logfile node".into());
+        }
+
+        if let log_ql::parser::GrammarItem::Condition { ref field, ref value } = right_node.entry {
+            conditional_field = field.clone();
+            conditional_value = value.clone();
+        } else {
+            return Err("Couldn't deref Conditional node".into());
+        }
+
+        Ok((log_filename, query_fields, conditional_field, conditional_value))
     }
 
-    Ok((log_filename, query_fields, conditional_field, conditional_value))
-  }
+    fn filter_log_file(&self, log_file: log_file::LogFile, query_fields: Vec<String>, conditional_field: String, conditional_value: String) -> Vec<String> {
+        log_file
+            .search_field(conditional_field, conditional_value)
+            .iter()
+            .flat_map(|r| {
+                query_fields
+                    .iter()
+                    .map(|query_field| r.get_field(query_field))
+                    .collect::<Option<String>>()
+            })
+            .collect::<Vec<String>>()
+    }
 
-  fn filter_log_file(&self, log_file: log_file::LogFile, query_fields: Vec<String>, conditional_field: String, conditional_value: String) -> Vec<String> {
-    log_file
-      .search_field(conditional_field, conditional_value)
-      .iter()
-      .flat_map(|r| {
-          query_fields
-              .iter()
-              .map(|query_field| r.get_field(query_field))
-              .collect::<Option<String>>()
-      })
-      .collect::<Vec<String>>()
-  }
+    pub fn execute_query(&self, query: String) -> Result<Vec<String>, String> {
+        let (log_filename, query_fields, conditional_field, conditional_value) = self.parse(query)?;
 
-  pub fn execute_query(&self, query: String) -> Result<Vec<String>, String> {
-    let (log_filename, query_fields, conditional_field, conditional_value) = self.parse(query)?;
-
-    let log_file = log_file::from_file(self.working_directory.join(log_filename), &self.configuration);
-    Ok(self.filter_log_file(log_file, query_fields, conditional_field, conditional_value))
-  }
+        let log_file = log_file::from_file(self.working_directory.join(log_filename), &self.configuration);
+        Ok(self.filter_log_file(log_file, query_fields, conditional_field, conditional_value))
+    }
 }

--- a/src/query_request.rs
+++ b/src/query_request.rs
@@ -1,0 +1,17 @@
+pub struct QueryRequest {
+    pub log_filename: String,
+    pub query_fields: Vec<String>,
+    pub conditional_field: String,
+    pub conditional_value: String
+}
+
+impl QueryRequest {
+    pub fn new(log_filename: String, query_fields: Vec<String>, conditional_field: String, conditional_value: String) -> QueryRequest {
+        QueryRequest {
+            log_filename: log_filename,
+            query_fields: query_fields,
+            conditional_field: conditional_field,
+            conditional_value: conditional_value
+        }
+    }
+}

--- a/src/query_request.rs
+++ b/src/query_request.rs
@@ -1,17 +1,64 @@
 pub struct QueryRequest {
     pub log_filename: String,
     pub query_fields: Vec<String>,
-    pub conditional_field: String,
-    pub conditional_value: String
+    pub conditional_field: Option<String>,
+    pub conditional_value: Option<String>
 }
 
 impl QueryRequest {
-    pub fn new(log_filename: String, query_fields: Vec<String>, conditional_field: String, conditional_value: String) -> QueryRequest {
+    pub fn new(log_filename: String, query_fields: Vec<String>, conditional_field: Option<String>, conditional_value: Option<String>) -> QueryRequest {
         QueryRequest {
             log_filename: log_filename,
             query_fields: query_fields,
             conditional_field: conditional_field,
             conditional_value: conditional_value
         }
+    }
+}
+
+pub struct QueryRequestBuilder {
+    pub log_filename: Option<String>,
+    pub query_fields: Option<Vec<String>>,
+    pub conditional_field: Option<String>,
+    pub conditional_value: Option<String>
+}
+
+impl QueryRequestBuilder {
+    pub fn new() -> QueryRequestBuilder {
+        QueryRequestBuilder {
+            log_filename: None,
+            query_fields: None,
+            conditional_field: None,
+            conditional_value: None
+        }
+    }
+
+    pub fn set_log_filename(&mut self, log_filename: String) -> &mut Self {
+        self.log_filename = Some(log_filename);
+        self
+    }
+
+    pub fn set_query_fields(&mut self, query_fields: Vec<String>) -> &mut Self {
+        self.query_fields = Some(query_fields);
+        self
+    }
+
+    pub fn set_conditional_field(&mut self, conditional_field: String) -> &mut Self {
+        self.conditional_field = Some(conditional_field);
+        self
+    }
+
+    pub fn set_conditional_value(&mut self, conditional_value: String) -> &mut Self {
+        self.conditional_value = Some(conditional_value);
+        self
+    }
+
+    pub fn build(self) -> QueryRequest {
+        QueryRequest::new(
+            self.log_filename.expect("log filename must be present"),
+            self.query_fields.expect("query fields must be present"),
+            self.conditional_field,
+            self.conditional_value
+        )
     }
 }


### PR DESCRIPTION
This PR ships with a fixed indentation for the query context. 

There's also now a `QueryRequestBuilder` which helps building the `QueryRequest`. Both of these structs will make it easier to deal with optional where clauses later on.